### PR TITLE
add `Validity` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +205,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -238,6 +251,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enum-map"
@@ -344,6 +363,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc3e639bcba360d9237acabd22014c16f3df772db463b7446cd81b070714767"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "similar",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,12 +401,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
 name = "krust"
 version = "0.1.0"
 dependencies = [
  "bio",
  "dashmap",
  "fxhash",
+ "insta",
  "rayon",
 ]
 
@@ -394,6 +434,12 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "matrixmultiply"
@@ -528,6 +574,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "ordered-float"
@@ -754,6 +806,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa 1.0.2",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "simba"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +839,12 @@ dependencies = [
  "num-traits",
  "paste",
 ]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "statrs"
@@ -817,6 +898,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -883,3 +974,34 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ dashmap = "4.0.2"
 fxhash = "0.2.1"
 rayon = "*"
 
+[dev-dependencies]
+insta     = "1.14.1"

--- a/src/kmer.rs
+++ b/src/kmer.rs
@@ -3,13 +3,21 @@
 pub struct Kmer(pub Vec<u8>);
 
 impl Kmer {
-    pub fn new(sub: &[u8]) -> Option<Kmer> {
-        if !sub.contains(&b'N') {
-            let valid_kmer = sub.to_vec();
-            Some(Kmer(valid_kmer))
-        } else {
-            None
-        }
+    pub fn new() -> Kmer {
+        Kmer(Vec::new())
+    }
+
+    fn add(&mut self, elem: u8) {
+        self.0.push(elem)
+    }
+
+    pub fn from_substring(sub: &[u8]) -> Result<Self, ()> {
+        sub.into_iter()
+            .map(|b| match b.parse_valid_byte() {
+                Ok(b) => Ok(b),
+                Err(()) => return Err(()),
+            })
+            .collect::<Result<Kmer, ()>>()
     }
 
     /// Find the index of the rightmost invalid byte in an invalid bytestring.
@@ -21,5 +29,49 @@ impl Kmer {
             Some(rightmost_invalid_byte_index) => rightmost_invalid_byte_index,
             None => panic!("Valid bytestring passed to `find_invalid`, which is a bug."),
         }
+    }
+}
+
+impl FromIterator<u8> for Kmer {
+    fn from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Self {
+        let mut k = Kmer::new();
+
+        for i in iter {
+            k.add(i);
+        }
+        k
+    }
+}
+
+trait Validity {
+    fn parse_valid_byte(self) -> Result<Self, ()>
+    where
+        Self: Sized;
+}
+
+impl Validity for u8 {
+    fn parse_valid_byte(self) -> Result<Self, ()> {
+        match &[b'A', b'C', b'G', b'T'].contains(&self) {
+            true => Ok(self),
+            false => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn test_from_substring() {
+        let sub = &[b'C', b'A', b'G', b'T'];
+        match Kmer::from_substring(sub) {
+            Ok(k) => insta::assert_snapshot!(format!("{:?}", k), @"Kmer([67, 65, 71, 84])"),
+            Err(()) => panic!("this should not happen"),
+        }
+
+        let sub = &[b'C', b'N', b'G', b'T'];
+        let k = Kmer::from_substring(sub);
+	assert!(k.is_err());
     }
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -61,8 +61,9 @@ fn process_seq(seq: &[u8], k: &usize, kmer_map: &DashFx) {
     let mut i = 0;
     while i <= seq.len() - k {
         let sub = &seq[i..i + k];
-        let bytestring = Kmer::new(sub);
-        if let Some(Kmer(valid_bytestring)) = bytestring {
+        let bytestring = Kmer::from_substring(sub);
+        //let bytestring = Kmer(sub.to_vec());
+        if let Ok(Kmer(valid_bytestring)) = bytestring {
             process_valid_bytes(kmer_map, valid_bytestring);
             i += 1;
         } else {

--- a/tests/kmer_new.rs
+++ b/tests/kmer_new.rs
@@ -1,17 +1,18 @@
 use krust::kmer::Kmer;
-
+/*
 #[test]
 fn kmer_new_returns_valid_kmer() {
     let dna = "CATAG".as_bytes();
     let result = {
-        match Kmer::new(dna) {
+        match Kmer(dna) {
             Some(Kmer(valid_bytestring)) => valid_bytestring,
             None => vec![b'N'; 5],
         }
     };
     assert_eq!("CATAG".as_bytes().to_vec(), result);
 }
-
+ */
+/*
 #[test]
 fn kmer_new_returns_none_for_invalid_kmer() {
     let dna = "CANAG".as_bytes();
@@ -23,3 +24,4 @@ fn kmer_new_returns_none_for_invalid_kmer() {
     };
     assert_eq!(None, result);
 }
+*/


### PR DESCRIPTION
Use `FromIter` and a custom `Validity` trait to enforce validity of k-mer substrings.